### PR TITLE
chore: switch to weekly dependency updates

### DIFF
--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -4,7 +4,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 * * 1
 jobs:
   upgrade:
     name: Upgrade

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -5,6 +5,7 @@
 
 import { IResolver, License } from "projen";
 import { ConstructLibraryCdktf } from "projen/lib/cdktf";
+import { UpgradeDependenciesSchedule } from "projen/lib/javascript"
 import { TypeScriptProject } from "projen/lib/typescript";
 
 const SPDX = "MPL-2.0";
@@ -60,6 +61,7 @@ const project = new ConstructLibraryCdktf({
   depsUpgradeOptions: {
     workflowOptions: {
       labels: ["auto-approve", "dependencies"],
+      schedule: UpgradeDependenciesSchedule.WEEKLY,
     },
   },
   projenrcTs: true,

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -5,7 +5,7 @@
 
 import { IResolver, License } from "projen";
 import { ConstructLibraryCdktf } from "projen/lib/cdktf";
-import { UpgradeDependenciesSchedule } from "projen/lib/javascript"
+import { UpgradeDependenciesSchedule } from "projen/lib/javascript";
 import { TypeScriptProject } from "projen/lib/typescript";
 
 const SPDX = "MPL-2.0";


### PR DESCRIPTION
Right now this codebase does a nightly release, usually because of small Projen updates, which seems like overkill and might be confusing to users who are wondering why there are so many releases. Switching to weekly should be fine for this project.