### PR TITLE
chore(deps)!: increase minimum supported version of cdk8s to 2.8.0

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "cdk8s-cli",
-      "version": ">=2.0",
+      "version": ">=2.3",
       "type": "build"
     },
     {
@@ -110,7 +110,7 @@
     },
     {
       "name": "yaml",
-      "version": "1.10.2",
+      "version": "2.3.4",
       "type": "bundled"
     },
     {
@@ -120,7 +120,7 @@
     },
     {
       "name": "cdk8s",
-      "version": ">=2.1.6",
+      "version": ">=2.8.0",
       "type": "peer"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -33,7 +33,7 @@ const project = new ConstructLibraryCdktf({
   authorAddress: "https://hashicorp.com",
   authorOrganization: true,
   defaultReleaseBranch: "main",
-  bundledDeps: ["yaml@1.10.2"],
+  bundledDeps: ["yaml@2.3.4"],
   licensed: false,
   projenrcTs: true,
   prettier: true,
@@ -71,11 +71,11 @@ new UpgradeCDKTF(project);
 project.addPeerDeps(
   "constructs@^10.0.25",
   "@cdktf/provider-kubernetes@>=10.0.0",
-  "cdk8s@>=2.1.6",
+  "cdk8s@>=2.8.0",
   "cdktf@>=0.19.0"
 );
 
-project.addDevDeps("cdk8s-cli@>=2.0", "ts-node@10.9.1");
+project.addDevDeps("cdk8s-cli@>=2.3", "ts-node@10.9.1");
 
 project.testTask.prependExec(
   `cd ./test && cdk8s import k8s --language typescript`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ By using the software in this repository, you acknowledge that:
 ## Compatibility
 
 - `cdktf` >= 0.19.0
-- `cdk8s` >= 2.1.6
+- `cdk8s` >= 2.8.0
 - `constructs` >= 10.0.25
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^6",
     "@typescript-eslint/parser": "^6",
-    "cdk8s": "2.1.6",
-    "cdk8s-cli": ">=2.0",
+    "cdk8s": "2.8.0",
+    "cdk8s-cli": ">=2.3",
     "cdktf": "0.19.0",
     "constructs": "10.0.25",
     "eslint": "^8",
@@ -65,12 +65,12 @@
   },
   "peerDependencies": {
     "@cdktf/provider-kubernetes": ">=10.0.0",
-    "cdk8s": ">=2.1.6",
+    "cdk8s": ">=2.8.0",
     "cdktf": ">=0.19.0",
     "constructs": "^10.0.25"
   },
   "dependencies": {
-    "yaml": "1.10.2"
+    "yaml": "2.3.4"
   },
   "bundledDependencies": [
     "yaml"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1874,7 +1874,7 @@ case@^1.6.3:
   resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
   integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
 
-cdk8s-cli@>=2.0:
+cdk8s-cli@>=2.3:
   version "2.184.0"
   resolved "https://registry.yarnpkg.com/cdk8s-cli/-/cdk8s-cli-2.184.0.tgz#19614e97f1f462688d2d195c0542405d067126f4"
   integrity sha512-dwwNIMHjOHZQeMeimMz36jgLwrryXWANi8/ABS5JHBk9ULwoQASme8u8zerlwR1sjQV2fSVn0UuySD/7wj9Vxg==
@@ -1907,14 +1907,16 @@ cdk8s-plus-25@^2.22.65:
   optionalDependencies:
     backport "8.5.0"
 
-cdk8s@2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/cdk8s/-/cdk8s-2.1.6.tgz#193946f8e600b64fde3b97e71112c045bc73b53f"
-  integrity sha512-ioF2+oe98T6u848orvO3ATmS6kYSdOwuFrEp3Z9Yr17JE73BKY+3MJ03/NonnlkDmr7vn2WsLqx3W8/TOO9vJQ==
+cdk8s@2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/cdk8s/-/cdk8s-2.8.0.tgz#9f9f8c60100c0f92c9a1abd1fad21ead840987e8"
+  integrity sha512-QbZ4QMGDzGLLBzrLI9PyEp/KMoP9rtUiuVT6U3a8lAvdR0ageYnl5HPTh5pJS35I9DlLLi6sT5GUntRizYIBFg==
   dependencies:
-    fast-json-patch "^2.2.1"
-    follow-redirects "^1.14.6"
-    yaml "2.0.0-7"
+    fast-json-patch "^3.1.1"
+    follow-redirects "^1.15.2"
+    yaml "2.3.1"
+  optionalDependencies:
+    backport "8.5.0"
 
 cdk8s@^2.68.11:
   version "2.68.12"
@@ -3049,11 +3051,6 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
-fast-deep-equal@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
-  integrity sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==
-
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -3074,13 +3071,6 @@ fast-glob@^3.2.9, fast-glob@^3.3.2:
     glob-parent "^5.1.2"
     merge2 "^1.3.0"
     micromatch "^4.0.4"
-
-fast-json-patch@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-2.2.1.tgz#18150d36c9ab65c7209e7d4eb113f4f8eaabe6d9"
-  integrity sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==
-  dependencies:
-    fast-deep-equal "^2.0.1"
 
 fast-json-patch@^3.1.1:
   version "3.1.1"
@@ -3191,7 +3181,7 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.14.6, follow-redirects@^1.14.9, follow-redirects@^1.15.2:
+follow-redirects@^1.14.9, follow-redirects@^1.15.2:
   version "1.15.3"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
   integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
@@ -7431,15 +7421,10 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
-
-yaml@2.0.0-7:
-  version "2.0.0-7"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-7.tgz#9799d9d85dfc8f01e4cc425e18e09215364beef1"
-  integrity sha512-RbI2Tm3hl9AoHY4wWyWvGvJfFIbHOzuzaxum6ez1A0vve+uXgNor03Wys4t+2sgjJSVSe+B2xerd1/dnvqHlOA==
+yaml@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.1.tgz#02fe0975d23cd441242aa7204e09fc28ac2ac33b"
+  integrity sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==
 
 yaml@2.3.2:
   version "2.3.2"


### PR DESCRIPTION
Fixes https://github.com/cdktf/cdktf-cdk8s/security/dependabot/19
Fixes https://github.com/cdktf/cdktf-cdk8s/security/dependabot/20